### PR TITLE
feat(enrichment): surface narratives, proposed_relationships, verified flag (closes #4)

### DIFF
--- a/pydantic/project_output.py
+++ b/pydantic/project_output.py
@@ -22,9 +22,16 @@ class ExternalReference(BaseModel):
     """Reference to external database or resource."""
 
     source: str = Field(description="Source name (e.g., 'yad_vashem', 'jri_poland')")
-    url: str | None = Field(default=None, description="URL to the record")
+    url: str | None = Field(default=None, description="URL to the record (may be null for negative-evidence citations)")
     record_id: str | None = Field(default=None, description="Record identifier")
     notes: str | None = Field(default=None, description="Additional notes")
+    verified: bool | None = Field(
+        default=None,
+        description="True if a human has reviewed and confirmed this citation",
+    )
+
+
+EnrichmentSource = Literal["flash", "deep_research"]
 
 
 # =============================================================================
@@ -208,6 +215,24 @@ class AdditionalDetail(BaseModel):
     value: str = Field(description="Detail value")
 
 
+class BiographicalNarrative(BaseModel):
+    """Long-form provenanced narrative produced by Flash / Deep Research pipelines."""
+
+    source: EnrichmentSource = Field(description="Producing pipeline")
+    markdown: str = Field(description="Markdown-formatted narrative text")
+
+
+class ProposedRelationship(BaseModel):
+    """Unconfirmed relationship hypothesis awaiting human review."""
+
+    type: str = Field(description="Relationship type (e.g., 'sibling_of', 'cousin')")
+    person_id_hint: str = Field(
+        description="Free-form hint identifying the target person (id guess + context)"
+    )
+    evidence: str = Field(description="Evidence justifying the proposed link")
+    source: EnrichmentSource = Field(description="Producing pipeline")
+
+
 class EnrichedPerson(BaseModel):
     """A person with all enrichment data."""
 
@@ -247,6 +272,14 @@ class EnrichedPerson(BaseModel):
     )
     additional_details: list[AdditionalDetail] | None = Field(
         default=None, description="Additional biographical details"
+    )
+    biographical_narratives: list[BiographicalNarrative] | None = Field(
+        default=None,
+        description="Long-form sourced narratives from Flash / Deep Research enrichment",
+    )
+    proposed_relationships: list[ProposedRelationship] | None = Field(
+        default=None,
+        description="Unconfirmed relationship hypotheses awaiting human review",
     )
 
 

--- a/zod/enrichment.schema.test.ts
+++ b/zod/enrichment.schema.test.ts
@@ -7,6 +7,7 @@ import {
 	EnrichmentDataSchema,
 	LocationTypeSchema,
 } from './enrichment.schema';
+import { ExternalReferenceSchema } from './shared.schema';
 
 describe('Enrichment Schemas', () => {
 	describe('EnrichedPersonSchema', () => {
@@ -52,6 +53,77 @@ describe('Enrichment Schemas', () => {
 				external_references: [],
 			};
 			expect(() => EnrichedPersonSchema.parse(person)).toThrow();
+		});
+
+		it('accepts person with biographical_narratives and proposed_relationships', () => {
+			const person = {
+				id: 'person-aaron-yurevitch',
+				name: 'Aron Judewicz',
+				aliases: [],
+				gender: 'male',
+				holocaust_fate: 'perished',
+				unit_ids: ['cu-1'],
+				relationships: [],
+				external_references: [],
+				biographical_narratives: [
+					{
+						source: 'deep_research',
+						markdown: '**Aron Judewicz** was deeply embedded in the smuggling networks…',
+					},
+					{ source: 'flash', markdown: 'Yizkor plaque notes his role as gabbai.' },
+				],
+				proposed_relationships: [
+					{
+						type: 'sibling_of',
+						person_id_hint: 'Salomon Judewicz (brother, perished Auschwitz 1943)',
+						evidence: 'Both named as resident brothers in 1939 deportation list.',
+						source: 'deep_research',
+					},
+				],
+			};
+			expect(() => EnrichedPersonSchema.parse(person)).not.toThrow();
+		});
+
+		it('rejects biographical_narratives entry with invalid source', () => {
+			const person = {
+				id: 'person-1',
+				name: 'Test',
+				aliases: [],
+				gender: 'unknown',
+				holocaust_fate: 'unknown',
+				unit_ids: [],
+				relationships: [],
+				external_references: [],
+				biographical_narratives: [{ source: 'gpt', markdown: '...' }], // invalid source
+			};
+			expect(() => EnrichedPersonSchema.parse(person)).toThrow();
+		});
+	});
+
+	describe('ExternalReferenceSchema', () => {
+		it('accepts url: null for negative-evidence citations', () => {
+			const ref = {
+				source: 'yad-vashem',
+				url: null,
+				notes: 'Negative evidence: no record found under any spelling',
+				verified: false,
+			};
+			expect(() => ExternalReferenceSchema.parse(ref)).not.toThrow();
+		});
+
+		it('accepts verified: true', () => {
+			const ref = {
+				source: 'jri-poland',
+				url: 'https://example.com/record/123',
+				record_id: 'JRI-12345',
+				verified: true,
+			};
+			expect(() => ExternalReferenceSchema.parse(ref)).not.toThrow();
+		});
+
+		it('accepts omitted verified and url (backward compat)', () => {
+			const ref = { source: 'Yad Vashem' };
+			expect(() => ExternalReferenceSchema.parse(ref)).not.toThrow();
 		});
 	});
 

--- a/zod/enrichment.schema.ts
+++ b/zod/enrichment.schema.ts
@@ -32,6 +32,25 @@ export const AdditionalDetailSchema = z.object({
 });
 export type AdditionalDetail = z.infer<typeof AdditionalDetailSchema>;
 
+// Provenanced source for narratives and proposed relationships
+const EnrichmentSourceSchema = z.enum(['flash', 'deep_research']);
+
+// Long-form biographical narrative produced by Flash / Deep Research pipelines
+export const BiographicalNarrativeSchema = z.object({
+	source: EnrichmentSourceSchema,
+	markdown: z.string(),
+});
+export type BiographicalNarrative = z.infer<typeof BiographicalNarrativeSchema>;
+
+// Unconfirmed relationship hypothesis awaiting human review
+export const ProposedRelationshipSchema = z.object({
+	type: z.string(),
+	person_id_hint: z.string(),
+	evidence: z.string(),
+	source: EnrichmentSourceSchema,
+});
+export type ProposedRelationship = z.infer<typeof ProposedRelationshipSchema>;
+
 // Enriched Person
 export const EnrichedPersonSchema = z.object({
 	id: z.string(),
@@ -55,6 +74,8 @@ export const EnrichedPersonSchema = z.object({
 	relationships: z.array(RelationshipSchema),
 	external_references: z.array(ExternalReferenceSchema),
 	additional_details: z.array(AdditionalDetailSchema).optional(),
+	biographical_narratives: z.array(BiographicalNarrativeSchema).optional(),
+	proposed_relationships: z.array(ProposedRelationshipSchema).optional(),
 });
 export type EnrichedPerson = z.infer<typeof EnrichedPersonSchema>;
 

--- a/zod/shared.schema.ts
+++ b/zod/shared.schema.ts
@@ -21,9 +21,10 @@ export type ContentType = z.infer<typeof ContentTypeSchema>;
 
 export const ExternalReferenceSchema = z.object({
 	source: z.string(),
-	url: z.string().optional(),
+	url: z.string().nullable().optional(),
 	record_id: z.string().optional(),
 	notes: z.string().optional(),
+	verified: z.boolean().optional(),
 });
 export type ExternalReference = z.infer<typeof ExternalReferenceSchema>;
 


### PR DESCRIPTION
## Summary

Resolves #4 — adds the four fields the deep-research and pinkasdownloader pipelines emit but the schema currently drops on parse, plus the Pydantic twin.

### Zod additions

- **`ExternalReferenceSchema`** (\`zod/shared.schema.ts\`)
  - \`url\` → \`.nullable().optional()\` (allows explicit \`null\` for negative-evidence citations like \"no Yad Vashem record found\")
  - \`verified: z.boolean().optional()\` (indicates whether a human has reviewed the citation)
- **\`EnrichedPersonSchema\`** (\`zod/enrichment.schema.ts\`)
  - \`biographical_narratives\` — array of \`{source: 'flash' | 'deep_research', markdown: string}\`
  - \`proposed_relationships\` — array of \`{type, person_id_hint, evidence, source}\` (unconfirmed hypotheses awaiting human review)

### Field-shape decision

The issue sketched \`proposed_relationships\` with \`{target_id, target_name}\`; the actual data emits \`person_id_hint\` (single freeform string combining ID guess + context, e.g., \`\"Salomon Judewicz (brother, perished Auschwitz-Birkenau 1943)\"\`). This PR matches the data as-emitted. If the pipeline later evolves to structured targets, we can layer that on without breaking existing data.

### Pydantic mirror

Identical additions to \`pydantic/project_output.py\` with two new nested classes (\`BiographicalNarrative\`, \`ProposedRelationship\`) and a shared \`EnrichmentSource\` literal.

### Tests

4 new cases in \`zod/enrichment.schema.test.ts\`:
- Person with narratives + proposed relationships parses
- Narrative with invalid source rejects
- ExternalReference with \`url: null\` + \`verified: false\` parses
- ExternalReference with \`verified: true\` and \`record_id\` parses
- ExternalReference with omitted \`verified\`/\`url\` parses (backward compat)

### Validation against real data

In pruzhany-svelte (after copying the edited schema files into the submodule path):

- \`bunx vitest run src/lib/schemas\` → 11/11 pass
- \`bun run validate:data\` → all 5 editions parse cleanly (including the 1938-12-16 enrichment data merged in pruzhany-svelte#133 which has 38 narratives + 21 proposed relationships + 226 unverified external references)
- \`bun run check\` → 0 errors, 0 warnings

### Downstream

After merge:
- \`dsmedia/pruzhany-svelte\` — bump \`src/vendor/pruzhany-schema\` pin, unblocks pruzhany-svelte#134 (PersonView rendering)
- \`dsmedia/pruzhany-press\` — bump \`vendor/pruzhany-schema\` pin (no Python consumers yet, kept for parity)

## Test plan

- [x] All Zod tests pass (\`bunx vitest run src/lib/schemas\` via consumer symlink)
- [x] Real-world validation: \`bun run validate:data\` clean on the 1938-12-16 edition
- [x] Typecheck clean (\`bun run check\`)
- [ ] Reviewer confirms \`person_id_hint\` (vs split target_id/target_name) is the right call for now