### PR TITLE
chore: add mise pins + justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ scan:
 
 # Run the zod/*.test.ts suite via the pruzhany-svelte sibling checkout's vitest.
 test-zod:
-    cd ../pruzhany-svelte && npx vitest run src/lib/schemas
+    cd ../pruzhany-svelte && bunx vitest run src/lib/schemas
 
 # Run the Zod<->Pydantic drift gate via the pruzhany-press sibling checkout.
 test-contract:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,24 @@
+# pruzhany-schema command runner. This repo is a pure contract layer with no
+# build or test of its own (CLAUDE.md "Testing") — the two delegating recipes
+# below run this repo's tests from its sibling consumer checkouts, exactly as
+# CLAUDE.md documents. `pre-commit-install`/`scan` wrap the one thing that is
+# genuinely local: the gitleaks secret scan (.pre-commit-config.yaml).
+
+default:
+    @just --list
+
+# One-time setup per clone: install and register the gitleaks pre-commit hook.
+pre-commit-install:
+    uv tool install pre-commit && pre-commit install
+
+# Run the pre-commit hooks (gitleaks) against the whole repo.
+scan:
+    pre-commit run --all-files
+
+# Run the zod/*.test.ts suite via the pruzhany-svelte sibling checkout's vitest.
+test-zod:
+    cd ../pruzhany-svelte && npx vitest run src/lib/schemas
+
+# Run the Zod<->Pydantic drift gate via the pruzhany-press sibling checkout.
+test-contract:
+    cd ../pruzhany-press && uv run --group dev python -m pytest tests/contract/

--- a/justfile
+++ b/justfile
@@ -9,11 +9,11 @@ default:
 
 # One-time setup per clone: install and register the gitleaks pre-commit hook.
 pre-commit-install:
-    uv tool install pre-commit && pre-commit install
+    uv tool install pre-commit && uvx pre-commit install
 
 # Run the pre-commit hooks (gitleaks) against the whole repo.
 scan:
-    pre-commit run --all-files
+    uvx pre-commit run --all-files
 
 # Run the zod/*.test.ts suite via the pruzhany-svelte sibling checkout's vitest.
 test-zod:

--- a/mise.toml
+++ b/mise.toml
@@ -5,3 +5,4 @@
 [tools]
 bun = "1.3.11"
 python = "3.11"
+just = "1.56.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+# pruzhany-schema has no build/test of its own (see CLAUDE.md "Testing") — its
+# two trees are exercised by the consumer repos. Versions below match those
+# consumers (pruzhany-svelte's bun pin, pruzhany-press's python floor) so a
+# clone of this repo alone stays compatible with both.
+[tools]
+bun = "1.3.11"
+python = "3.11"


### PR DESCRIPTION
## Summary
- Adds `mise.toml` pinning `bun 1.3.11` and `python 3.11` — this repo has no build/test of its own (CLAUDE.md "Testing"), so these match the consumer repos' pins for a compatible standalone clone.
- Adds a `justfile`: `pre-commit-install`/`scan` wrap the genuinely-local gitleaks hook; `test-zod`/`test-contract` are thin delegating wrappers around the two commands CLAUDE.md already documents for exercising this repo's schemas from the `pruzhany-svelte`/`pruzhany-press` sibling checkouts.
- No build/test behavior changes.

## Test plan
- [x] `just --list` parses cleanly
- [x] `just test-contract` (against sibling `pruzhany-press` checkout) — 1 passed
- [x] `just test-zod` (against sibling `pruzhany-svelte` checkout) — 23 passed