### PR TITLE
gitignore: never commit a Claude Code worktree into its own repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ Thumbs.db
 # Env
 .env
 .env.local
+
+# Claude Code local state — a worktree is a full checkout; committing one puts
+# the repo inside itself. pruzhany-svelte has carried these rules since before
+# worktrees were used here; this brings the repo in line with it.
+.claude/worktrees/
+.claude/projects/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## The gap

`.claude/worktrees/` holds full repository checkouts. Nothing had been committed, but the directory showed as untracked, so a stray `git add .` would have committed a copy of the repo into itself.

## What the sweep actually found

The first pass tested `.claude/` and reported all five repos exposed. That was the wrong test — `.claude/` is *correctly* tracked in `pruzhany-press` and `pruzhany-svelte`, which keep commands, rules, skills and `settings.json` there. Testing `.claude/worktrees/` gives the real picture:

| Repo | Before |
|---|---|
| `pruzhany-svelte` | ✅ already in committed `.gitignore` — the model copied here |
| `heritage-meta` | ⚠️ `.git/info/exclude` only — per-machine, never leaves the clone |
| `pruzhany-press` | ⚠️ `.git/info/exclude` only |
| `heritage-sources` | ❌ no rule |
| `pruzhany-schema` | ❌ no rule |

`.git/info/exclude` is not shared, so a fresh clone or a second contributor had no protection at all.

## What this adds

```
.claude/worktrees/
.claude/projects/
.claude/scheduled_tasks.lock
```

Matching the block `pruzhany-svelte` already carries.

**`settings.local.json` is deliberately NOT ignored.** STATUS records it as configuration drift awaiting adjudication; ignoring it would quietly end that.

Config only — no code, no data.